### PR TITLE
removed colon from path and enclosed in curly braces as suggested by Err

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,8 @@ async fn main() {
 
     let app = Router::new()
         .route("/pow_challenge", get(get_pow_challenge))
-        .route("/claim_l1/:solution/:address", get(claim_l1))
-        .route("/claim_l2/:solution/:address", get(claim_l2))
+        .route("/claim_l1/{solution}/{address}", get(claim_l1))
+        .route("/claim_l2/{solution}/{address}", get(claim_l2))
         .route("/balance", get(get_balance))
         .layer(SETTINGS.ip_src.clone().into_extension())
         .with_state(state);


### PR DESCRIPTION
Fixes following Errs:
```
2025-03-10T06:33:57.485005Z  INFO alpen_faucet::l2: L2 faucet address: 0x36cDE26C99815475F9a29E9E71c6C615529D16BD
thread 'main' panicked at src/main.rs:97:10:
Path segments must not start with `:`. For capture groups, use `{capture}`. If you meant to literally match a segment starting with a colon, call `without_v07_checks` on the router.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
...
2025-03-10T06:27:25.713900Z ERROR batcher: alpen_faucet::batcher: error receiving PayoutRequest: SendClosed
```