### PR TITLE
STR-1133 Debug faucet balance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,14 +120,13 @@ async fn get_pow_challenge(
     SecureClientIp(ip): SecureClientIp,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<PowChallenge>, (StatusCode, &'static str)> {
-    let balance = state
-        .l1_wallet
-        .read()
-        .balance()
-        .confirmed
-        .to_sat();
+    let balance_str = get_balance(State(state)).await;
 
-    if balance < SETTINGS.sats_per_claim.to_sat() {
+    let balance_u64: u64 = balance_str.parse().map_err(|_| {
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse balance")
+    })?;
+
+    if balance_u64 < SETTINGS.sats_per_claim.to_sat() {
         return Err((StatusCode::INTERNAL_SERVER_ERROR, "Insufficient funds"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,9 @@ async fn get_pow_challenge(
 ) -> Result<Json<PowChallenge>, (StatusCode, &'static str)> {
     let balance_str = get_balance(State(state)).await;
 
-    let balance_u64: u64 = balance_str.parse().map_err(|_| {
-        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse balance")
-    })?;
+    let balance_u64: u64 = balance_str
+        .parse()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse balance"))?;
 
     if balance_u64 < SETTINGS.sats_per_claim.to_sat() {
         return Err((StatusCode::INTERNAL_SERVER_ERROR, "Insufficient funds"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ pub struct PowChallenge {
 
 async fn get_pow_challenge(
     SecureClientIp(ip): SecureClientIp,
+    State(state): State<Arc<AppState>>,
 ) -> Result<Json<PowChallenge>, (StatusCode, &'static str)> {
     let balance_str = get_balance(State(state)).await;
 


### PR DESCRIPTION
Based on my investigation the following error doesn't show up when the faucet has sufficient balance.
```
2025-03-04T12:23:18.902989Z ERROR alpen_faucet: error sending transaction: ErrorResp(ErrorPayload { code: -32003, message: "insufficient funds for gas * price + value", data: None })
```
It's probably best to return error from `pow_challenge` in case of insufficient funds.