### PR TITLE
chore(deps): bump ring to >=0.17.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",


### PR DESCRIPTION
fixes RUSTSEC-2025-0009