### PR TITLE
Update batching period based on block time of 10 mins

### DIFF
--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -41,7 +41,7 @@ pub struct BatcherNotAvailable(SendError);
 pub struct BatcherConfig {
     /// How long the period for transaction batching is.
     ///
-    /// Defaults to `30` seconds.
+    /// Defaults to `180` seconds.
     pub period: Duration,
 
     /// Maximum number of transactions to batch per batching period.
@@ -58,7 +58,7 @@ pub struct BatcherConfig {
 impl Default for BatcherConfig {
     fn default() -> Self {
         Self {
-            period: Duration::from_secs(30),
+            period: Duration::from_secs(180),
             max_per_tx: 250,
             max_in_flight: 2500,
         }


### PR DESCRIPTION
Signet block time is now 10 minutes. The 30 second batching period was meant for a block time of 30 seconds. Update batching period to 3 minutes. @Zk2u suggested a value in the range 2-5 minutes.