### PR TITLE
strata -> alpen

### DIFF
--- a/src/pow.rs
+++ b/src/pow.rs
@@ -152,7 +152,7 @@ impl Challenge {
         };
 
         let mut hasher = Sha256::new();
-        hasher.update(b"strata faucet 2024");
+        hasher.update(b"alpen faucet 2024");
         hasher.update(challenge.nonce);
         hasher.update(solution);
 


### PR DESCRIPTION
We are getting Invalid Proof of Work due to "strata faucet 2024" passed to hasher. The alpen-cli uses "alpen faucet 2024".

See [STR-1402](https://alpenlabs.atlassian.net/browse/STR-1402)