### PR TITLE
chore: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 /rustfmt.toml @Zk2u
 **/Cargo.toml @Zk2u
 **/Cargo.lock @Zk2u
-**/justfile @storopoli
+**/justfile @Zk2u @storopoli
 **/LICENSE* @storopoli
 **/README.md @Zk2u
 **/.gitignore @Zk2u
@@ -19,14 +19,14 @@
 /src/pow.rs @Zk2u @storopoli
 /src/batcher.rs @Zk2u
 /src/l1.rs @Zk2u
-/src/l2.rs @krsnapaudel @bewakes
+/src/l2.rs @Zk2u @krsnapaudel @bewakes
 /src/settings.rs @Zk2u @storopoli
 /src/seed.rs @Zk2u
 /src/macros.rs @Zk2u
 
 # Other components
 /utils/ @Zk2u
-/faucet.toml @krsnapaudel @purusang
+/faucet.toml @Zk2u @krsnapaudel @purusang
 
 # CI/CD
 /.github/ @storopoli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,4 +35,4 @@
 # Docker
 **/Dockerfile @purusang
 **/.dockerignore @purusang
-**/entrypoint.sh @purusang
+**/entrypoint.sh @Zk2u @krsnapaudel @purusang

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 
 # CI/CD
 /.github/ @storopoli
+.github/workflows/cd.yml @purusang @storopoli
 /.codecov.yml @storopoli
 
 # Docker

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Based on git blame analysis and initial implementations.
+
+* @Zk2u # fallback
+
+# Bookkeeping
+*.toml @Zk2u
+*.md @Zk2u
+/rust-toolchain.toml @Zk2u
+/rustfmt.toml @Zk2u
+**/Cargo.toml @Zk2u
+**/Cargo.lock @Zk2u
+**/justfile @storopoli
+**/LICENSE* @storopoli
+**/README.md @Zk2u
+**/.gitignore @Zk2u
+
+# Modules
+/src/main.rs @Zk2u
+/src/pow.rs @Zk2u @storopoli
+/src/batcher.rs @Zk2u
+/src/l1.rs @Zk2u
+/src/l2.rs @krsnapaudel @bewakes
+/src/settings.rs @Zk2u @storopoli
+/src/seed.rs @Zk2u
+/src/macros.rs @Zk2u
+
+# Other components
+/utils/ @Zk2u
+/faucet.toml @krsnapaudel @purusang
+
+# CI/CD
+/.github/ @storopoli
+/.codecov.yml @storopoli
+
+# Docker
+**/Dockerfile @purusang
+**/.dockerignore @purusang
+**/entrypoint.sh @purusang


### PR DESCRIPTION
This adds a `CODEOWNERS` file to the repo.
I used my judgement to assign usernames here using three criteria:

1. Who was the first implementer of the component
2. `git blame` analyses for frequency of contribution
3. Who was comfortable working on certain things and also is well known to have notorious knowledge about it

I also tried to balance things out between us.

Let's f**** bikeshed this properly. I am in no rush to merge this and let's get it right. I don't want to see people get hurt by this, but empowered.
I want this to "spark joy".