### PR TITLE
Different POW difficultly for L1 and L2 and accomodate the equation for dynamic POW

### DIFF
--- a/faucet.toml
+++ b/faucet.toml
@@ -4,7 +4,15 @@ ip_src = "ConnectInfo"
 seed_file = "faucet.seed"
 sqlite_file = "faucet.sqlite"
 network = "signet"
-esplora = "https://esplora.testnet.alpenlabs.io"
-l2_http_endpoint = "https://rpc.testnet.alpenlabs.io"
-l1_sats_per_claim = 1_001_000_000
-l2_sats_per_claim = 101_000_000
+esplora = "https://esplora.testnet-staging.stratabtc.org"
+l2_http_endpoint = "https://rpc.testnet-staging.stratabtc.org"
+l1_sats_per_claim = 1001000000
+l2_sats_per_claim = 10000000
+
+[l1_pow]
+min_balance = 50000000000  # 500 BTC
+min_difficulty = 17
+
+[l2_pow]
+min_balance = 10000000000  # 100 BTC
+min_difficulty = 17        # Slightly easier for L2

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,13 +173,19 @@ async fn get_pow_challenge(
     };
 
     if let IpAddr::V4(ip) = ip {
+        let chain_config = match chain {
+            Chain::L1 => &SETTINGS.l1_pow,
+            Chain::L2 => &SETTINGS.l2_pow,
+        };
+        
         let difficulty = pow::calculate_difficulty(
             balance.to_btc() as f32,
             u8::MAX as f32,
-            SETTINGS.pow.min_difficulty as f32,
-            SETTINGS.pow.min_balance.to_btc() as f32,
+            chain_config.min_difficulty as f32,
+            chain_config.min_balance.to_btc() as f32,
             need.to_btc() as f32,
         ) as u8;
+
         let challenge = Challenge::get(&ip, difficulty);
         Ok(Json(ProvidedChallenge {
             nonce: Hex(challenge.nonce()),


### PR DESCRIPTION
- Ability to set different POW difficulty for L1 and L2
```
<stub> 

[l1_pow]
min_balance = 50000000000  # 500 BTC
min_difficulty = 17

[l2_pow]
min_balance = 10000000000  # 100 BTC
min_difficulty = 17        # Slightly easier for L2
```

- Dynamic POW difficulty now works for balance per claim < 1 BTC


[Desmos Link](https://www.desmos.com/calculator/uorsmcruda)

<img width="1697" height="566" alt="image" src="https://github.com/user-attachments/assets/2a2560b1-5c8a-417c-8686-fb03ddbe7f45" />
